### PR TITLE
Add support for shows

### DIFF
--- a/lib/rspotify.rb
+++ b/lib/rspotify.rb
@@ -15,4 +15,5 @@ module RSpotify
   autoload :Track,              'rspotify/track'
   autoload :TrackLink,          'rspotify/track_link'
   autoload :User,               'rspotify/user'
+  autoload :Show,               'rspotify/show'
 end

--- a/lib/rspotify/show.rb
+++ b/lib/rspotify/show.rb
@@ -1,0 +1,43 @@
+module RSpotify
+  # @attr [Array<String>]   available_markets	    A list of the countries in which the show can be played, identified by their ISO 3166-1 alpha-2 code.
+  # @attr [Array<Hash>]     copyrights            The copyright statements of the show
+  # @attr [String]          description           A description of the show.
+  # @attr [Boolean]         explicit	            Whether or not the show has explicit content (true = yes it does; false = no it does not OR unknown).
+  # @attr [Array<Hash>]     episodes              A list of the show’s episodes inside a paging object
+  # @attr [Hash]            external_urls         Known external URLs for this show
+  # @attr [String]          href                  A link to the Web API endpoint providing full details of the show
+  # @attr [String]          id	                  The Spotify ID for the show
+  # @attr [Array<Hash>]     images                The cover art for the show in various sizes, widest first
+  # @attr [Boolean]         is_externally_hosted  True if all of the show’s episodes are hosted outside of Spotify’s CDN. This field might be null in some cases
+  # @attr [Array<String>]   languages             A list of the languages used in the show, identified by their ISO 639 code.
+  # @attr [String]          media_type            The media type of the show
+  # @attr [String]          name                  The name of the show
+  # @attr [String]          publisher             The publisher of the show
+  # @attr [String]          type                  The object type: "show"
+  # @attr [String]          uri	                  The Spotify URI for the show
+  # @attr [Integer]         total_episodes        Total number of episodes in the show
+
+  class Show < Base
+    def initialize(options = {})
+      @available_markets =    options['available_markets']
+      @copyrights =           options['copyrights']
+      @description =          options['description']
+      @explicit =             options['explicit']
+      @episodes =             options['episodes']
+      @external_urls =        options['external_urls']
+      @href =                 options['href']
+      @id =                   options['id']
+      @images =               options['images']
+      @is_externally_hosted = options['is_externally_hosted']
+      @languages =            options['languages']
+      @media_type =           options['media_type']
+      @name =                 options['name']
+      @publisher =            options['publisher']
+      @type =                 options['type']
+      @uri =                  options['uri']
+      @total_episodes =       options['total_episodes']
+
+      super(options)
+    end
+  end
+end

--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -423,6 +423,31 @@ module RSpotify
       User.oauth_get(@id, url)
     end
 
+    def subscribe_to_shows!(shows)
+      shows_ids = shows.map(&:id)
+      url = 'me/shows'
+      request_body = shows_ids.inspect
+      User.oauth_put(@id, url, request_body)
+    end
+
+    def subscribed_to_shows(limit: 20, offset: 0, market: nil)
+      url = "me/shows?limit=#{limit}&offset=#{offset}"
+      url << "&market=#{market}" if market
+      response = User.oauth_get(@id, url)
+      json = RSpotify.raw_response ? JSON.parse(response) : response
+
+      shows = json['items'].select { |i| i['show'] }
+
+      return response if RSpotify.raw_response
+      shows.map { |a| Show.new a['show'] }
+    end
+
+    def subscribed_to_shows?(shows)
+      shows_ids = shows.map(&:id)
+      url = "me/shows/contains?ids=#{shows_ids.join ','}"
+      User.oauth_get(@id, url)
+    end
+
     # Returns a hash containing all user attributes
     def to_hash
       pairs = instance_variables.map do |var|

--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -448,6 +448,12 @@ module RSpotify
       User.oauth_get(@id, url)
     end
 
+    def unsubscribe_from_shows!(shows)
+      shows_ids = shows.map(&:id)
+      url = "me/shows?ids=#{shows_ids.join ','}"
+      User.oauth_delete(@id, url)
+    end
+
     # Returns a hash containing all user attributes
     def to_hash
       pairs = instance_variables.map do |var|


### PR DESCRIPTION
Stupid Spotify wants an oauth token to pull data about a podcast, anything else works with just app secret. Why would they design an API like that... anyway, that's the reason why I'm not including a `find` method for a Show.

Not adding specs here as I wasn't going for a proper PR to their code base. The code is tested by an integration spec in main Gleam app though.