### PR TITLE
GLM-9684 - Fix Spotify#already_following_playlist

### DIFF
--- a/lib/rspotify/playlist.rb
+++ b/lib/rspotify/playlist.rb
@@ -128,8 +128,11 @@ module RSpotify
 
       super(options)
 
-      @path = "users/#{@owner.instance_variable_get('@id').gsub('?','')}/"
-      @path << (@href =~ /\/starred$/ ? 'starred' : "playlists/#{@id}")
+      @path = if @href =~ /\/starred$/
+        "users/#{@owner.instance_variable_get('@id').gsub('?','')}/starred"
+      else
+        "playlists/#{@id}"
+      end
     end
 
     # Adds one or more tracks to a playlist in user's Spotify account. This method is only available when the


### PR DESCRIPTION
## Change description

This follows the fix that was implement in here: https://github.com/Crowd9/Gleam/pull/26935

This goes towards the recent (2 weeks ago) changes also made on the original rspotify gem https://github.com/guilhermesad/rspotify/blob/master/lib/rspotify/playlist.rb#L131:L135. It doesn't necessarily fix the main issue, but after fixing the issue on our main Gleam repo, this issue was raised.

And seeing that the gem was updated recently, also makes me wonder if we shouldn't start using again the original gem, instead of the one that we forked to our Crowd9 repos.

## Type of change
- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [GLM-9684](https://linear.app/gleamio/issue/GLM-9684) 


