### PR TITLE
EntryActions::AuthExpiredError in SpotifySaveJob@spotify_save

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -381,8 +381,8 @@ module RSpotify
     def save_albums!(albums)
       albums_ids = albums.map(&:id)
       url = "me/albums"
-      request_body = albums_ids.inspect
-      User.oauth_put(@id, url, request_body)
+      request_body = { ids: albums_ids }
+      User.oauth_put(@id, url, request_body.to_json)
       albums
     end
 


### PR DESCRIPTION
Fix request for User#save_albums

Context: [GLM-11027](https://linear.app/gleamio/issue/GLM-11027)

@ponny another pertinent question that i can't ask you after you leave.. why do we use/have so many cloned repos?
In my head, if the main repo (in this case, this one https://github.com/guilhermesad/rspotify) is still used and updated, why did we our unmaintained repo?
Do you think we should have a Epic task, to revisit and try to start using the maintained repos instead of our unmaintained repos?

A similar problem was.. as we use our own shopify repo, i had to build a feature in our own shopify repo, instead of using the original repo, where that feature was already built, and also up to date. 