### PR TITLE
GLM-11320 - RestClient::Forbidden in entries#create

### DIFF
--- a/lib/rspotify/user.rb
+++ b/lib/rspotify/user.rb
@@ -425,9 +425,8 @@ module RSpotify
 
     def subscribe_to_shows!(shows)
       shows_ids = shows.map(&:id)
-      url = 'me/shows'
-      request_body = shows_ids.inspect
-      User.oauth_put(@id, url, request_body)
+      url = "me/shows?ids=#{shows_ids.join ','}"
+      User.oauth_put(@id, url, {}.to_json)
     end
 
     def subscribed_to_shows(limit: 20, offset: 0, market: nil)


### PR DESCRIPTION
The Spotify show follow feature was not working. This PR fixes that problem

### Before

https://github.com/user-attachments/assets/e0140092-da95-4214-8f1d-19c225fd9faf

### After

https://github.com/user-attachments/assets/ffede6a2-a720-429e-8592-4fd9adf628a9

